### PR TITLE
DL-6845 regress js version to work with IE11

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -3645,7 +3645,7 @@
     "@testing-library/jest-dom": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
-      "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
+      "integrity": "sha1-AN+gy92DfZo8Kn8/CiSOpue4l0I=",
       "requires": {
         "@babel/runtime": "^7.5.1",
         "chalk": "^2.4.1",
@@ -3671,7 +3671,7 @@
     "@testing-library/react": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
-      "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
+      "integrity": "sha1-cVMWVaeJC2Hnehs5RS++3wRyyl4=",
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@testing-library/dom": "^6.15.0",
@@ -3681,7 +3681,7 @@
     "@testing-library/user-event": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
-      "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA=="
+      "integrity": "sha1-KtToRBdaNzjLnnBkvl6gcLiGOhw="
     },
     "@types/babel__core": {
       "version": "7.1.10",
@@ -3771,7 +3771,7 @@
     "@types/jest": {
       "version": "24.9.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
-      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+      "integrity": "sha1-Arr5Vzx48bmXSl82d4s2aqd71TQ=",
       "requires": {
         "jest-diff": "^24.3.0"
       }
@@ -3799,7 +3799,7 @@
     "@types/numeral": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-0.0.28.tgz",
-      "integrity": "sha512-Sjsy10w6XFHDktJJdXzBJmoondAKW+LcGpRFH+9+zXEDj0cOH8BxJuZA9vUDSMAzU1YRJlsPKmZEEiTYDlICLw=="
+      "integrity": "sha1-5Dko8L2hCxabb37PmePd+Da46+Q="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -10682,7 +10682,7 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -10929,7 +10929,7 @@
     "node-sass": {
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
-      "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
+      "integrity": "sha1-mch+wu+3BH7WOPtMnbfzpC4iF7U=",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -12983,7 +12983,7 @@
     "react-axe": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/react-axe/-/react-axe-3.5.4.tgz",
-      "integrity": "sha512-5xNO0QVCCEZnJiyhAGox0MGFyclgU3XL8se+5H+whdxV1VTtA9/uux9BSCF5mGNSgtSZkb+tQtrOaF+zGf/oWw==",
+      "integrity": "sha1-9ZueoI64I0H1PLJsXFNyRBe8jI8=",
       "dev": true,
       "requires": {
         "axe-core": "^3.5.0",
@@ -13231,7 +13231,7 @@
     "react-router-dom": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "integrity": "sha1-nmWk0MReEyieZsexfH4XXQ6hVmI=",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",


### PR DESCRIPTION
Regressing sbt-scalajs version to work with IE11
Other changes are result of running sbt dist 