### PR TITLE
Dl 6791

### DIFF
--- a/app/uk/gov/hmrc/calculatenifrontend/ConfigLoader.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/ConfigLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/config/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/controllers/Binders.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/controllers/Binders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/controllers/CalculatorUIController.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/controllers/CalculatorUIController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/controllers/NiConfigController.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/controllers/NiConfigController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/controllers/TablesController.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/controllers/TablesController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/controllers/TablesController.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/controllers/TablesController.scala
@@ -85,22 +85,22 @@ class TablesController @Inject()(
         val selectedInterval = ni.classTwo.keySet.find(_.contains(dateP)).get
         val lowerBound = selectedInterval.lowerValue.get
         
-        val noOfWeeks = selectedInterval.numberOfWeeks().get
+//        val noOfWeeks = selectedInterval.numberOfWeeks().get
         val response = List (
           "Term Date" -> LocalDate.of(lowerBound.getYear, 4, 9).ukFormat, // unknown... but always the 9th of april
           "Weekly Rate" -> data.weeklyRate.default.toString,
-          "Rate Total" -> (data.weeklyRate.default * noOfWeeks).toString
+          "Rate Total" -> (data.weeklyRate.default * data.noOfWeeks).toString
         ) ++ (data.weeklyRate.voluntary match {
           case None => Nil
           case Some(vdw) => List (
             "Voluntary Development Workers (VDW) Weekly Rate" -> vdw,
-            "Voluntary Development Workers (VDW) Total" -> vdw * noOfWeeks
+            "Voluntary Development Workers (VDW) Total" -> vdw * data.noOfWeeks
           )
         }) ++ (data.weeklyRate.fishermen match {
           case None => Nil
           case Some(vdw) => List (
             "Share Fishing Weekly Rate" -> vdw.toString,
-            "Share Fishing Total" -> (vdw * noOfWeeks).toString
+            "Share Fishing Total" -> (vdw * data.noOfWeeks).toString
           )
         }) ++ List (
 //          "Date Late For Short Term Benefits (STB)" -> "???",
@@ -108,7 +108,7 @@ class TablesController @Inject()(
           "Small Profits Threshold/Small Earnings Exemption (SPT/SEE)" ->
             data.smallEarningsException.fold("N/A")(_.toString), // below which paying is optional
           "Date High Rate Provision (HRP) Applies" -> (lowerBound, data).getHigherRateDate.value.ukFormat, 
-          "No of Wks" -> noOfWeeks.toString,
+          "No of Wks" -> data.noOfWeeks.toString,
 //          "Earnings Factor (includes enhance)" -> "???",
         )
         Ok(genericPage(dateP, intervals, "Class 2", response.map{case (k,v) => (k,Html(v.toString))}))

--- a/app/uk/gov/hmrc/calculatenifrontend/views/ClassOneTablePage.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/ClassOneTablePage.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/ErrorTemplate.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/FooterLinks.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/FooterLinks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/GenericTableView.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/GenericTableView.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/Head.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/Head.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/HelloWorldPage.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/HelloWorldPage.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/Layout.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/helpers/breadcrumbs.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/helpers/breadcrumbs.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/calculatenifrontend/views/templates/niCalcLayout.scala.html
+++ b/app/uk/gov/hmrc/calculatenifrontend/views/templates/niCalcLayout.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val build                    = taskKey[Unit]("Copy JS and Config to react app")
 
 val appName = "calculate-ni-frontend"
 
-val silencerVersion = "1.7.7"
+val silencerVersion = "1.7.8"
 
 installReactDependencies := {
   val result = JavaScriptBuild.npmProcess(reactDirectory.value, "install").run().exitValue()
@@ -61,10 +61,10 @@ lazy val microservice = Project(appName, file("."))
     majorVersion                     := 0,
     scalaVersion                     := "2.12.14",
     libraryDependencies              ++= Seq(
-      "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.16.0",
-      "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.26.0-play-28",
-      "com.github.pureconfig"   %% "pureconfig"                 % "0.17.0",
-      "org.typelevel"           %% "cats-core"                  % "2.6.1",
+      "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.19.0",
+      "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.31.0-play-28",
+      "com.github.pureconfig"   %% "pureconfig"                 % "0.17.1",
+      "org.typelevel"           %% "cats-core"                  % "2.7.0",
       "org.typelevel"           %% "spire"                      % "0.17.0"
     ),
     libraryDependencies ++= Seq(
@@ -73,9 +73,9 @@ lazy val microservice = Project(appName, file("."))
       "io.circe" %%% "circe-parser"
     ).map(_ % circeVersion),
     libraryDependencies              ++= Seq(
-      "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.16.0",
+      "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.19.0",
       "com.typesafe.play"       %% "play-test"                  % play.core.PlayVersion.current,
-      "com.github.tototoshi"    %% "scala-csv"                  % "1.3.8",
+      "com.github.tototoshi"    %% "scala-csv"                  % "1.3.10",
       "org.scalatestplus"       %% "scalacheck-1-15"            % "3.2.9.0",
       "com.propensive"          %% "magnolia"                   % "0.17.0",
       "io.chrisdavenport"       %% "cats-scalacheck"            % "0.3.1"

--- a/common/src/main/scala/Bands.scala
+++ b/common/src/main/scala/Bands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassFour.scala
+++ b/common/src/main/scala/ClassFour.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassOneResult.scala
+++ b/common/src/main/scala/ClassOneResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassOneRowInput.scala
+++ b/common/src/main/scala/ClassOneRowInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassOneRowOutput.scala
+++ b/common/src/main/scala/ClassOneRowOutput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassThree.scala
+++ b/common/src/main/scala/ClassThree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassTwo.scala
+++ b/common/src/main/scala/ClassTwo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassTwoAndThreeResult.scala
+++ b/common/src/main/scala/ClassTwoAndThreeResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassTwoOrThree.scala
+++ b/common/src/main/scala/ClassTwoOrThree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ClassTwoRates.scala
+++ b/common/src/main/scala/ClassTwoRates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/Configuration.scala
+++ b/common/src/main/scala/Configuration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/ConfigurationPeriod.scala
+++ b/common/src/main/scala/ConfigurationPeriod.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/DirectorsResult.scala
+++ b/common/src/main/scala/DirectorsResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/DirectorsRowInput.scala
+++ b/common/src/main/scala/DirectorsRowInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/FileWatcher.scala
+++ b/common/src/main/scala/FileWatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/InterestResult.scala
+++ b/common/src/main/scala/InterestResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/JsonEncoding.scala
+++ b/common/src/main/scala/JsonEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/Limit.scala
+++ b/common/src/main/scala/Limit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/Money.scala
+++ b/common/src/main/scala/Money.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/Percentage.scala
+++ b/common/src/main/scala/Percentage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/Period.scala
+++ b/common/src/main/scala/Period.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/RateDefinition.scala
+++ b/common/src/main/scala/RateDefinition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/TaxYear.scala
+++ b/common/src/main/scala/TaxYear.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/UnofficialDefermentResult.scala
+++ b/common/src/main/scala/UnofficialDefermentResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/scala/package.scala
+++ b/common/src/main/scala/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/ClassOne.scala
+++ b/frontend/src/main/scala/ClassOne.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/ClassTwoAndThreeFrontend.scala
+++ b/frontend/src/main/scala/ClassTwoAndThreeFrontend.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/Directors.scala
+++ b/frontend/src/main/scala/Directors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/Frontend.scala
+++ b/frontend/src/main/scala/Frontend.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/InterestFrontend.scala
+++ b/frontend/src/main/scala/InterestFrontend.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/InterestOnRefundsClassOne.scala
+++ b/frontend/src/main/scala/InterestOnRefundsClassOne.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/InterestOnUnpaidFrontend.scala
+++ b/frontend/src/main/scala/InterestOnUnpaidFrontend.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/JsObjectAdaptor.scala
+++ b/frontend/src/main/scala/JsObjectAdaptor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/UnofficialDeferment.scala
+++ b/frontend/src/main/scala/UnofficialDeferment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/WeeklyContributions.scala
+++ b/frontend/src/main/scala/WeeklyContributions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/scala/package.scala
+++ b/frontend/src/main/scala/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/national-insurance.conf
+++ b/national-insurance.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/national-insurance.conf
+++ b/national-insurance.conf
@@ -68,7 +68,7 @@
   }
   class-two {
     final-date = 1978-04-05
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £536
     small-earnings-exception = £675
     weekly-rate {
@@ -438,7 +438,7 @@
   }
   class-two {
     final-date = 1983-04-05
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £1182
     small-earnings-exception = £1250
     weekly-rate {
@@ -1343,7 +1343,7 @@
   class-two {
     final-date = 1993-04-05
     hrp-date = 1988-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £1957
     small-earnings-exception = £2075
     weekly-rate {
@@ -2330,7 +2330,7 @@
   class-two {
     final-date = 1998-04-05
     hrp-date = 1993-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £2654
     small-earnings-exception = £2900
     weekly-rate {
@@ -3342,7 +3342,7 @@
   class-two {
     final-date = 2004-04-05
     hrp-date = 1999-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £3174
     small-earnings-exception = £3480
     weekly-rate {
@@ -3861,7 +3861,7 @@
   class-two {
     final-date = 2010-04-05
     hrp-date = 2005-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £3954
     small-earnings-exception = £4095
     weekly-rate {
@@ -4280,7 +4280,7 @@
   class-two {
     final-date = 2015-04-05
     hrp-date = 2010-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £4630
     small-earnings-exception = £4825
     weekly-rate {
@@ -4853,7 +4853,7 @@
   class-two {
     final-date = 2021-04-05
     hrp-date = 2016-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £5722
     small-earnings-exception = £5885
     weekly-rate {
@@ -4864,7 +4864,7 @@
   }
   class-three {
     final-date = 2021-04-05
-    no-of-weeks = 53
+    no-of-weeks = 52
     qualifying-rate = £5722
     week-rate = £13.90
   }
@@ -5283,7 +5283,7 @@
   class-two {
     final-date = 2026-04-05
     hrp-date = 2021-04-06
-    no-of-weeks = 52
+    no-of-weeks = 53
     qualifying-rate = £6086
     small-earnings-exception = £6365
     weekly-rate {
@@ -5294,7 +5294,7 @@
   }
   class-three {
     final-date = 2026-04-05
-    no-of-weeks = 53
+    no-of-weeks = 52
     qualifying-rate = £6086
     week-rate = £15
   }

--- a/national-insurance.conf
+++ b/national-insurance.conf
@@ -5465,6 +5465,7 @@
 
   class-two {
     final-date = 2028-04-05
+    no-of-weeks = 52
     qualifying-rate = £6190
     small-earnings-exception = £6515
     weekly-rate {
@@ -5477,6 +5478,7 @@
   class-three {
     final-date = 2028-04-05
     hrp-date = 2023-04-06
+    no-of-weeks = 52
     qualifying-rate = £6190
     week-rate = £15.40
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 

--- a/test/eoi/ArbitraryInstances.scala
+++ b/test/eoi/ArbitraryInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/ClassOneSpec.scala
+++ b/test/eoi/ClassOneSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/ClassThreeSpec.scala
+++ b/test/eoi/ClassThreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/ClassTwoSpec.scala
+++ b/test/eoi/ClassTwoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/ConfigWriterInstances.scala
+++ b/test/eoi/ConfigWriterInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/ConfigurationSpec.scala
+++ b/test/eoi/ConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/DeriveArbitrary.scala
+++ b/test/eoi/DeriveArbitrary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/DirectorsSpec.scala
+++ b/test/eoi/DirectorsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/SpreadsheetTest.scala
+++ b/test/eoi/SpreadsheetTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/TaxYearSpec.scala
+++ b/test/eoi/TaxYearSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/eoi/UnofficialDefermentSpec.scala
+++ b/test/eoi/UnofficialDefermentSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Initial fix for 2021 Class 2
Copyright updates for 2022
Fixing historic entries based on comments from SME
Dependency and plugin updates

Note - left scalacheck dependency at 3.2.9.0 as incrementing causes issue with flexmark 