### PR TITLE
DL-7905: Class one contributions update

### DIFF
--- a/app/uk/gov/hmrc/calculatenifrontend/ConfigLoader.scala
+++ b/app/uk/gov/hmrc/calculatenifrontend/ConfigLoader.scala
@@ -130,11 +130,13 @@ object ConfigLoader {
       categoryNames <- objCur.atKey("category-names") flatMap catReader.from
       interestLate  <- objCur.atKey("interest-on-late-payment") flatMap datePercentReader.from
       interestRepay <- objCur.atKey("interest-on-repayment") flatMap datePercentReader.from
+      directorsDiverge <- objCur.atKey("directors-diverge-date") flatMap localDateConvert.from
       yearsObj      =  objCur.withoutKey("interest-on-late-payment")
                              .withoutKey("interest-on-repayment")
                              .withoutKey("category-names")
+                             .withoutKey("directors-diverge-date")
       years         <- confPeriodReader.from(yearsObj)
-    } yield Configuration(categoryNames, years, interestLate, interestRepay)
+    } yield Configuration(categoryNames, years, interestLate, interestRepay, directorsDiverge)
   }
 
   lazy val default: Configuration = {

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val build                    = taskKey[Unit]("Copy JS and Config to react app")
 
 val appName = "calculate-ni-frontend"
 
-val silencerVersion = "1.7.8"
+val silencerVersion = "1.7.9"
 
 installReactDependencies := {
   val result = JavaScriptBuild.npmProcess(reactDirectory.value, "install").run().exitValue()
@@ -62,9 +62,9 @@ lazy val microservice = Project(appName, file("."))
     scalaVersion                     := "2.12.14",
     libraryDependencies              ++= Seq(
       "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.21.0",
-      "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "3.9.0-play-28",
+      "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "3.22.0-play-28",
       "com.github.pureconfig"   %% "pureconfig"                 % "0.17.1",
-      "org.typelevel"           %% "cats-core"                  % "2.7.0",
+      "org.typelevel"           %% "cats-core"                  % "2.8.0",
       "org.typelevel"           %% "spire"                      % "0.17.0"
     ),
     libraryDependencies ++= Seq(
@@ -105,7 +105,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(integrationTestSettings(): _*)
   .settings(resolvers += Resolver.jcenterRepo)
 
-val circeVersion = "0.14.1"
+val circeVersion = "0.14.2"
 
 /** common components holding the logic of the calculation */
 lazy val common = sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlatform, JVMPlatform)

--- a/common/src/main/scala/Configuration.scala
+++ b/common/src/main/scala/Configuration.scala
@@ -92,6 +92,9 @@ case class Configuration (
         }
     }
 
+  lazy val directorsImpl: Map[Interval[LocalDate], Map[String, RateDefinition]] =
+    classOne.filterKeys(_.doesNotContain(LocalDate.of(2022, 4, 6))) ++ directors
+
   lazy val classTwo: Map[Interval[LocalDate], ClassTwo] =
     data.collect{
       case (y,ConfigurationPeriod(l,_,Some(c2),_,_,_,_)) =>
@@ -163,7 +166,7 @@ case class Configuration (
     lazy val config =
       (directors.at(from), classOne.at(from)) match {
         case(Some(directors), _) => directors
-        case(_, Some(classOne))  => classOne
+        case(_, Some(classOne)) if (from.getYear != 2022) => classOne
         case _ => throw new IllegalStateException(s"No directors or C1 config defined for $from")
       }
 

--- a/frontend/src/main/scala/Directors.scala
+++ b/frontend/src/main/scala/Directors.scala
@@ -47,7 +47,7 @@ class Directors (
   ).toJSObject
 
   def getTaxYearsWithOptions: js.Array[String] =
-    config.classOne.keys.map(_.toString).toJSArray
+    config.directorsImpl.keys.map(_.toString).toJSArray
 
   def isAppropriatePersonalPensionSchemeApplicable(on: Date) =
     on.getYear < 2012

--- a/national-insurance.conf
+++ b/national-insurance.conf
@@ -5945,3 +5945,5 @@ interest-on-repayment {
   "[2009-01-27,2009-09-28]" = 0%
   "[2009-09-29,∞)" = 0.5%
 }
+
+directors-diverge-date = 2022-04-06

--- a/national-insurance.conf
+++ b/national-insurance.conf
@@ -5558,63 +5558,6 @@
       year = £11908
     }
   }
-
-  class-one {
-    # the intervals for the bands are inferred by the names.
-    # in this case 'up to X' will cause the configuration to look for a value for 'X'
-    # under limits above
-    "Up to LEL" {
-      # defining a 0% band will cause it to appear in the tables
-      employee.ABCFHIJLMSVZ = 0%
-      employer.ABCFHIJLMSVZ = 0%
-      hide-on-summary = false
-    }
-    "LEL to ST".employer.ABCFHIJLMSVZ = 0%
-    "LEL to PT" {
-      employee.ABCFHIJLMSVZ = 0%
-      hide-on-summary = false
-    }
-    "PT to UEL" {
-      hide-on-summary = false
-      employee {
-        AFHMV = 13.25%
-        BI = 7.1%
-        JLZ = 3.25%
-        CS = 0%
-      }
-    }
-    "ST to UEL" {}
-    "Above UEL" {
-      employee.ABFHIJLMVZ = 3.25%
-      employee.CS = 0%
-    }
-    "Above VUST" {
-      employer.V = 15.05%
-    }
-    "ST to UST" {
-      employer.ABCJ = 15.05%
-      employer.MZ = 0%
-    }
-    "ST to AUST" {
-      employer.H = 0%
-    }
-    "ST to VUST" {
-      employer.V = 0%
-    }
-    "Above UST" {
-      employer.ABCJMZ = 15.05%
-    }
-    "Above AUST" {
-      employer.H = 15.05%
-    }
-    "ST to FUST" {
-      employer.FILS = 0%
-    }
-    "Above FUST" {
-      employer.FILS = 15.05%
-    }
-  }
-
   class-two {
     final-date = 2029-04-05
     no-of-weeks = 52
@@ -5709,6 +5652,117 @@
    }
 }
 "[2022-04-06,2022-07-05]" {
+  limits {
+    # we can explicitly give values for weeks, months and 4weeks here
+    # but if we omit them it will get them from the year divided by 52, 12 and 13 respectively
+    LEL {
+      week = £123
+      four-week = £492
+      month = £533
+      year = £6396
+    }
+    ST {
+      week = £175
+      four-week = £700
+      month = £758
+      year = £9100
+    }
+    PT {
+      week = £190
+      four-week = £760
+      month = £823
+      year = £9880
+    }
+    FUST{
+      week = £481
+      four-week = £1924
+      month = £2083
+      year = £25000
+    }
+    UEL {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    AUST {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    UST {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    VUST {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    DPT {
+      week = £229
+      year = £11908
+    }
+  }
+  class-one {
+    # the intervals for the bands are inferred by the names.
+    # in this case 'up to X' will cause the configuration to look for a value for 'X'
+    # under limits above
+    "Up to LEL" {
+      # defining a 0% band will cause it to appear in the tables
+      employee.ABCFHIJLMSVZ = 0%
+      employer.ABCFHIJLMSVZ = 0%
+      hide-on-summary = false
+    }
+    "LEL to ST".employer.ABCFHIJLMSVZ = 0%
+    "LEL to PT" {
+      employee.ABCFHIJLMSVZ = 0%
+      hide-on-summary = false
+    }
+    "PT to UEL" {
+      hide-on-summary = false
+      employee {
+        AFHMV = 13.25%
+        BI = 7.1%
+        JLZ = 3.25%
+        CS = 0%
+      }
+    }
+    "ST to UEL" {}
+    "Above UEL" {
+      employee.ABFHIJLMVZ = 3.25%
+      employee.CS = 0%
+    }
+    "Above VUST" {
+      employer.V = 15.05%
+    }
+    "ST to UST" {
+      employer.ABCJ = 15.05%
+      employer.MZ = 0%
+    }
+    "ST to AUST" {
+      employer.H = 0%
+    }
+    "ST to VUST" {
+      employer.V = 0%
+    }
+    "Above UST" {
+      employer.ABCJMZ = 15.05%
+    }
+    "Above AUST" {
+      employer.H = 15.05%
+    }
+    "ST to FUST" {
+      employer.FILS = 0%
+    }
+    "Above FUST" {
+      employer.FILS = 15.05%
+    }
+  }
    class-four {
      lower-limit = £9880
      main-rate = 10.25%
@@ -5717,6 +5771,117 @@
    }
 }
 "[2022-07-06,2023-04-05]" {
+  limits {
+    # we can explicitly give values for weeks, months and 4weeks here
+    # but if we omit them it will get them from the year divided by 52, 12 and 13 respectively
+    LEL {
+      week = £123
+      four-week = £492
+      month = £533
+      year = £6396
+    }
+    ST {
+      week = £175
+      four-week = £700
+      month = £758
+      year = £9100
+    }
+    PT {
+      week = £242
+      four-week = £968
+      month = £1048
+      year = £12570
+    }
+    FUST{
+      week = £481
+      four-week = £1924
+      month = £2083
+      year = £25000
+    }
+    UEL {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    AUST {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    UST {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    VUST {
+      week = £967
+      four-week = £3867
+      month = £4189
+      year = £50270
+    }
+    DPT {
+      week = £229
+      year = £11908
+    }
+  }
+  class-one {
+    # the intervals for the bands are inferred by the names.
+    # in this case 'up to X' will cause the configuration to look for a value for 'X'
+    # under limits above
+    "Up to LEL" {
+      # defining a 0% band will cause it to appear in the tables
+      employee.ABCFHIJLMSVZ = 0%
+      employer.ABCFHIJLMSVZ = 0%
+      hide-on-summary = false
+    }
+    "LEL to ST".employer.ABCFHIJLMSVZ = 0%
+    "LEL to PT" {
+      employee.ABCFHIJLMSVZ = 0%
+      hide-on-summary = false
+    }
+    "PT to UEL" {
+      hide-on-summary = false
+      employee {
+        AFHMV = 13.25%
+        BI = 7.1%
+        JLZ = 3.25%
+        CS = 0%
+      }
+    }
+    "ST to UEL" {}
+    "Above UEL" {
+      employee.ABFHIJLMVZ = 3.25%
+      employee.CS = 0%
+    }
+    "Above VUST" {
+      employer.V = 15.05%
+    }
+    "ST to UST" {
+      employer.ABCJ = 15.05%
+      employer.MZ = 0%
+    }
+    "ST to AUST" {
+      employer.H = 0%
+    }
+    "ST to VUST" {
+      employer.V = 0%
+    }
+    "Above UST" {
+      employer.ABCJMZ = 15.05%
+    }
+    "Above AUST" {
+      employer.H = 15.05%
+    }
+    "ST to FUST" {
+      employer.FILS = 0%
+    }
+    "Above FUST" {
+      employer.FILS = 15.05%
+    }
+  }
    class-four {
      lower-limit = £12570
      main-rate = 10.25%

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.7.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 


### PR DESCRIPTION
The split tax year introduced in [DL-8138](https://github.com/hmrc/calculate-ni-frontend/pull/246) now contains class ones also, to allow for a different PT limit in each part of the tax year. Logic also updated so that you can choose one of the split tax years when calculating class one, but directors calculation apply to the whole tax year. 