### PR TITLE
DL-15248: Updated dependencies for calculate-ni-frontend:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ val build                    = taskKey[Unit]("Copy JS and Config to react app")
 
 val appName = "calculate-ni-frontend"
 
-val scalaLanguageVersion = "2.13.14"
-val bootstrapVersion = "9.1.0"
+val scalaLanguageVersion = "2.13.15"
+val bootstrapVersion = "9.6.0"
 val catsVersion = "2.12.0"
 
 installReactDependencies := {
@@ -64,8 +64,8 @@ lazy val microservice = Project(appName, file("."))
     scalaVersion                     := scalaLanguageVersion,
     libraryDependencies              ++= Seq(
       "uk.gov.hmrc"           %% "bootstrap-frontend-play-30" % bootstrapVersion,
-      "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "10.5.0",
-      "com.github.pureconfig" %% "pureconfig"                 % "0.17.7",
+      "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "11.10.0",
+      "com.github.pureconfig" %% "pureconfig"                 % "0.17.8",
       "org.typelevel"         %% "cats-core"                  % catsVersion,
       "org.typelevel"         %% "spire"                      % "0.18.0"
     ),
@@ -101,7 +101,7 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(resolvers += Resolver.jcenterRepo)
 
-val circeVersion = "0.14.9"
+val circeVersion = "0.14.10"
 
 /** common components holding the logic of the calculation */
 lazy val common = sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -1,31 +1,38 @@
 import org.scalajs.linker.interface.ESVersion
+
 import scala.sys.process._
+
 val reactDirectory           = settingKey[File]("The directory where the react application is located")
 val installReactDependencies = taskKey[Unit]("Install the dependencies for the react application")
 val buildReactApp            = taskKey[Unit]("Build the react application")
 val copyInJS                 = taskKey[File]("Build and copy in the JS file")
 val moveReact                = taskKey[Int]("move the compiled react application into the play assets")
 val build                    = taskKey[Unit]("Copy JS and Config to react app")
+
 val appName = "calculate-ni-frontend"
 val scalaLanguageVersion = "2.13.16"
 val bootstrapVersion = "9.7.0"
 val catsVersion = "2.12.0"
+
 installReactDependencies := {
   val result = JavaScriptBuild.npmProcess(reactDirectory.value, "install").run().exitValue()
   if (result != 0)
     throw new Exception("Npm install failed.")
 }
+
 copyInJS := {
   // generate the Javascript logic
   val Attributed(outFiles) = (frontend / Compile / fullOptJS).value
   val dest = reactDirectory.value / "src" / "calculation.js"
   println(s"copying $outFiles to $dest")
+
   // suppress warnings in generated code
   (Process("echo" ::
     """|/* eslint-disable */
        |var BigInt = function(n) { return n; };""".stripMargin :: Nil)
     #> dest
-    ).run().exitValue()
+  ).run().exitValue()
+
   // get around BigInt compatibility issues with IE11/scalajs1
   (Process("sed" ::
     "-e" :: """s/"object"===typeof __ScalaJSEnv&&__ScalaJSEnv?__ScalaJSEnv://""" ::
@@ -33,6 +40,7 @@ copyInJS := {
     baseDirectory.value) #>> dest).run().exitValue()
   dest
 }
+
 buildReactApp := {
   val deps: Unit = installReactDependencies.value
   val reactJsFile: Unit = copyInJS.value
@@ -40,12 +48,14 @@ buildReactApp := {
   if (result != 0)
     throw new Exception("npm run build failed.")
 }
+
 moveReact := {
   val reactApp: Unit = buildReactApp.value
   import scala.sys.process.{Process, ProcessBuilder}
   val result = Process("./sync-build.sh" :: Nil, baseDirectory.value).run().exitValue()
   1
 }
+
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .settings(
@@ -66,8 +76,8 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies              ++= Seq(
       "uk.gov.hmrc"          %% "bootstrap-test-play-30" % bootstrapVersion,
       "com.github.tototoshi" %% "scala-csv"              % "2.0.0",
-      "org.scalatestplus"    %% "scalacheck-1-18"        % "3.2.19.0",
-      "com.softwaremill.magnolia1_2"       %% "magnolia"               % "1.1.10",
+      "org.scalatestplus"    %% "scalacheck-1-17"        % "3.2.18.0",
+      "com.propensive"       %% "magnolia"               % "0.17.0",
       "io.chrisdavenport"    %% "cats-scalacheck"        % "0.3.2",
       "com.vladsch.flexmark" %  "flexmark-all"           % "0.64.8"
     ).map(_ % Test),
@@ -89,7 +99,9 @@ lazy val microservice = Project(appName, file("."))
     dist := (dist dependsOn moveReact).value
   )
   .settings(resolvers += Resolver.jcenterRepo)
+
 val circeVersion = "0.14.10"
+
 /** common components holding the logic of the calculation */
 lazy val common = sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlatform, JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
@@ -117,6 +129,7 @@ lazy val common = sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlatform
     publish := {},
     publishLocal := {}
   )
+
 /** ScalaJS calculation logic, used by the react frontend */
 lazy val `frontend` = project
   .enablePlugins(ScalaJSPlugin)
@@ -143,4 +156,3 @@ lazy val `frontend` = project
     publishLocal := {}
   )
   .dependsOn(common.js)
-maintainer := "test@hmrc.com"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,22 +1,12 @@
 resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
   Resolver.ivyStylePatterns)
-
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
-
 resolvers += Resolver.typesafeRepo("releases")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
-
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-
-addSbtPlugin("org.playframework"  % "sbt-plugin"  % "3.0.4")
-
+addSbtPlugin("org.playframework"  % "sbt-plugin"  % "3.0.6")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
-
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.18.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
-


### PR DESCRIPTION
com.github.pureconfig:pureconfig        : 0.17.7  -> 0.17.8
io.circe:circe-core                     : 0.14.9  -> 0.14.10
io.circe:circe-generic                  : 0.14.9  -> 0.14.10
io.circe:circe-parser                   : 0.14.9  -> 0.14.10
org.scala-lang:scala-library            : 2.13.14 -> 2.13.15
uk.gov.hmrc:bootstrap-frontend-play-30  : 9.1.0              -> 9.6.0
uk.gov.hmrc:bootstrap-test-play-30:test : 9.1.0              -> 9.6.0
 uk.gov.hmrc:play-frontend-hmrc-play-30  : 10.5.0             -> 10.13.0 -> 11.10.0