### PR TITLE
Revert "DL-18894: 1998/1999 earnings figure missing fix"

### DIFF
--- a/national-insurance.conf
+++ b/national-insurance.conf
@@ -1689,12 +1689,6 @@
       year = £16900
     }
   }
-  class-one {
-    "Earnings" {
-      year = "[0,16900]"
-      hide-on-summary = false
-    }
-  }
   class-two {
     final-date = 1996-04-05
     hrp-date = 1991-04-06


### PR DESCRIPTION
Reverts hmrc/calculate-ni-frontend#333

accidentally edited 1989 instead of 1998 